### PR TITLE
BUG: Homepage news link does not use page navigation label (issue #3)

### DIFF
--- a/code/pagetypes/ExpressHomePage.php
+++ b/code/pagetypes/ExpressHomePage.php
@@ -94,6 +94,10 @@ class ExpressHomePage_Controller extends Page_Controller {
 		}
 	}
 
+	public function getNews(){
+		return DataObject::get_one("NewsHolder");
+	}
+
 	/**
 	 * Overrides the ContentControllerSearchExtension and adds snippets to results.
 	 */


### PR DESCRIPTION
Return link to newsholder

Fixes: https://github.com/silverstripe-labs/silverstripe-express/issues/3
