### PR TITLE
Fix for the error generated adding a quicklink in a class extending ExpressHomePage

### DIFF
--- a/code/model/QuickLink.php
+++ b/code/model/QuickLink.php
@@ -7,7 +7,7 @@ class Quicklink extends DataObject {
 	);
 
 	static $has_one = array(
-		'Parent' => 'HomePage',
+		'Parent' => 'ExpressHomePage',
 		'InternalLink' => 'SiteTree'
 	);
 


### PR DESCRIPTION
Renamed the parent object declaration in the quick links has_one array from HomePage to ExpressHomePage. This fixes an error in the cms that was preventing the creation of quick links in a page that extends ExpressHomePage. The error generated was from the injector class when it was trying to instantiate a singleton of type HomePage, which did not exit.
