### PR TITLE
BUG: Scaffolding sitetrees fail at 100 db records

### DIFF
--- a/code/model/CarouselItem.php
+++ b/code/model/CarouselItem.php
@@ -25,6 +25,8 @@ class CarouselItem extends DataObject {
 		$fields = parent::getCMSFields();	
 		$fields->removeByName('Archived');
 
+		$fields->addFieldToTab('Root.Main', new TreeDropdownField('LinkID', 'Link', 'SiteTree'));
+
 		$fields->addFieldToTab('Root.Main', $group = new CompositeField(
 			$label = new LabelField("LabelArchive","Archive this carousel item?"),
 			new CheckboxField('Archived', '')
@@ -35,7 +37,9 @@ class CarouselItem extends DataObject {
 
 		$fields->removeByName('ParentID');
 
-		$fields->insertBefore(			
+
+
+		$fields->insertBefore(
 		$wrap = new CompositeField(
 			$extraLabel = new LabelField('Note', "Note: You will need to create the carousel item before you can add an image")
 		), 'Image');

--- a/code/model/QuickLink.php
+++ b/code/model/QuickLink.php
@@ -31,21 +31,24 @@ class Quicklink extends DataObject {
 		$fields->removeByName('ParentID');
 
 		$externalLinkField = $fields->fieldByName('Root.Main.ExternalLink');
-		$internalLinkField = $fields->fieldByName('Root.Main.InternalLinkID');
+
 		$fields->removeByName('ExternalLink');
 		$fields->removeByName('InternalLinkID');
-		$internalLinkField->addExtraClass('noBorder');
-		$externalLinkField->addExtraClass('noBorder');
+		
 
 		$fields->addFieldToTab('Root.Main',CompositeField::create(
 			array(
-				$internalLinkField,
+				$internalLinkField = new TreeDropdownField('InternalLinkID', 'Internal Link', 'SiteTree'),
 				$externalLinkField,
 				$wrap = new CompositeField(
 					$extraLabel = new LiteralField('NoteOverride', '<div class="message good notice">Note:  If you specify an External Link, the Internal Link will be ignored.</div>')
 				)
 			)
 		));
+
+		$internalLinkField->addExtraClass('noBorder');
+		$externalLinkField->addExtraClass('noBorder');
+
 		$fields->insertBefore(new LiteralField('Note', '<p>Use this to specify a link to a page either on this site (Internal Link) or another site (External Link).</p>'), 'Name');
 
 		return $fields;


### PR DESCRIPTION
The sitetree is intentionally replaced with a numeric field at 100 records. This pull request removes the reliance we had on the default scaffolding by replacing the sitetree dropdowns in express with treedropdown fields.
